### PR TITLE
add visualization of coordinator log messages on the CLI screen

### DIFF
--- a/meshmesh/apiframe.go
+++ b/meshmesh/apiframe.go
@@ -27,6 +27,8 @@ const (
 	startApiFrame      byte = 0xFE
 	escapeApiFrame     byte = 0xEA
 	stopApiFrame       byte = 0xEF
+	startLogMsg		   byte = 0x1B
+	stopLogMsg		   byte = 0x0A
 )
 
 const echoApiRequest uint8 = 0


### PR DESCRIPTION
This allow the coordinator to output his logging messages to be shown in the CLI scherm.

to enable this just set the *logging:* baud_rate the same value as set in the *meshmesh* component.
Like:

```yaml
logger:
  level: debug
  baud_rate: 460800
```