### PR TITLE
feat(docker): adjustable restart delay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ WORKDIR /root/
 
 COPY --from=builder /app/meshmeshgo .
 
+COPY docker-entrypoint.sh .
+RUN chmod +x docker-entrypoint.sh
+
 EXPOSE 4040
 
-CMD ["./meshmeshgo"]
+# CMD ["./meshmeshgo"]
+CMD ["./docker-entrypoint.sh"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,8 @@ services:
     container_name: meshmeshgo
     network_mode: host
     privileged: true
+    environment:
+      - MESHMESH_RESTART_DELAY=10
     volumes:
       - ./meshmeshgo.json:/root/meshmeshgo.json:rw
       - ./meshmesh.graphml:/root/meshmesh.graphml:rw

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+DELAY=${MESHMESH_RESTART_DELAY:-5}   # default to 5 seconds if not set
+
+while true; do
+  ./meshmeshgo
+  echo "meshmeshgo crashed (exit code $?). Restarting in ${DELAY}s..."
+  sleep "$DELAY"
+done


### PR DESCRIPTION
Docker immediately restarts app on crash too frequently before the backoff kicks in. This prevents that so that usb devices are not enumerated too quickly.